### PR TITLE
Tokio async support

### DIFF
--- a/sctp-rs/Cargo.toml
+++ b/sctp-rs/Cargo.toml
@@ -14,3 +14,4 @@ license-file = "LICENSE"
 [dependencies]
 os_socketaddr = { version = "0.2" }
 libc = { version = "0.2" }
+tokio = { version = "1.0" , features = ["net", "macros", "rt"]}

--- a/sctp-rs/src/connected_socket.rs
+++ b/sctp-rs/src/connected_socket.rs
@@ -70,15 +70,15 @@ impl SctpConnectedSocket {
     /// Receive Data or Notification from the listening socket.
     ///
     /// This function returns either a notification or the data.
-    pub fn sctp_recv(&self) -> std::io::Result<SctpNotificationOrData> {
-        sctp_recvmsg_internal(*self.inner.get_ref())
+    pub async fn sctp_recv(&self) -> std::io::Result<SctpNotificationOrData> {
+        sctp_recvmsg_internal(&self.inner).await
     }
 
     /// Send Data and Anciliary data if any on the SCTP Socket.
     ///
     /// This function returns the result of Sending data on the socket.
-    pub fn sctp_send(&self, data: SctpSendData) -> std::io::Result<()> {
-        sctp_sendmsg_internal(*self.inner.get_ref(), None, data)
+    pub async fn sctp_send(&self, data: SctpSendData) -> std::io::Result<()> {
+        sctp_sendmsg_internal(&self.inner, None, data).await
     }
 
     /// Event Subscription for the socket.

--- a/sctp-rs/src/connected_socket.rs
+++ b/sctp-rs/src/connected_socket.rs
@@ -8,7 +8,7 @@ use std::os::unix::io::RawFd;
 #[allow(unused)]
 use crate::internal::*;
 use crate::{
-    BindxFlags, SctpAssociationId, SctpEvent, SctpNotificationOrData, SctpSendData,
+    BindxFlags, SctpAssociationId, SctpEvent, SctpNotificationOrData, SctpSendData, SctpStatus,
     SubscribeEventAssocId,
 };
 
@@ -104,6 +104,11 @@ impl SctpConnectedSocket {
     /// Request to receive `SctpNxtInfo` ancillary data
     pub fn sctp_request_nxtinfo(&self, on: bool) -> std::io::Result<()> {
         request_nxtinfo_internal(*self.inner.get_ref(), on)
+    }
+
+    /// Get's the status of the connection associated with the association ID
+    pub fn sctp_get_status(&self, assoc_id: SctpAssociationId) -> std::io::Result<SctpStatus> {
+        sctp_get_status_internal(*self.inner.get_ref(), assoc_id)
     }
 }
 

--- a/sctp-rs/src/connected_socket.rs
+++ b/sctp-rs/src/connected_socket.rs
@@ -35,6 +35,9 @@ impl SctpConnectedSocket {
     /// Socket to Association) or [`peeloff`][`crate::SctpListener::sctp_peeloff`] (in the case of
     /// One to Many Association) would use this API to create new [`SctpConnectedSocket`].
     pub fn from_rawfd(rawfd: RawFd) -> std::io::Result<Self> {
+        // Make sure that the FD is set as non-blocking.
+        set_fd_non_blocking(rawfd)?;
+
         Ok(Self {
             inner: AsyncFd::new(rawfd)?,
         })

--- a/sctp-rs/src/consts.rs
+++ b/sctp-rs/src/consts.rs
@@ -16,6 +16,7 @@ pub(crate) static SCTP_GET_LOCAL_ADDRS: libc::c_int = 109;
 
 // To connect to an SCTP server.
 pub(crate) static SCTP_SOCKOPT_CONNECTX: libc::c_int = 110;
+pub(crate) static SCTP_SOCKOPT_CONNECTX3: libc::c_int = 111;
 
 // To subscribe to SCTP Events
 pub(crate) static SCTP_EVENT: libc::c_int = 127;
@@ -32,3 +33,6 @@ pub(crate) const SCTP_INITMSG: libc::c_int = 2;
 // Receving RCVINFO and NXTINFO
 pub(crate) const SCTP_RECVRCVINFO: libc::c_int = 32;
 pub(crate) const SCTP_RECVNXTINFO: libc::c_int = 33;
+
+// Get SCTP Status
+pub(crate) const SCTP_STATUS: libc::c_int = 14;

--- a/sctp-rs/src/internal.rs
+++ b/sctp-rs/src/internal.rs
@@ -245,7 +245,7 @@ pub(crate) fn sctp_connectx_internal(
             Err(std::io::Error::last_os_error())
         } else {
             Ok((
-                SctpConnectedSocket::from_rawfd(fd),
+                SctpConnectedSocket::from_rawfd(fd)?,
                 result as SctpAssociationId,
             ))
         }
@@ -261,7 +261,10 @@ pub(crate) fn accept_internal(fd: RawFd) -> std::io::Result<(SctpConnectedSocket
     addrs_buff.reserve(32);
     let mut addrs_len = addrs_buff.len();
 
-    eprintln!("addrs_len: {}, addrs_u8: {:?}", addrs_len, addrs_buff,);
+    eprintln!(
+        "accept_internal: addrs_len: {}, addrs_u8: {:?}",
+        addrs_len, addrs_buff,
+    );
     // Safety: Both `addrs_buff` and `addrs_len` are in the scope and hence are valid pointers.
     unsafe {
         let addrs_len_ptr = std::ptr::addr_of_mut!(addrs_len);
@@ -277,11 +280,14 @@ pub(crate) fn accept_internal(fd: RawFd) -> std::io::Result<(SctpConnectedSocket
         } else {
             let os_socketaddr = OsSocketAddr::from_raw_parts(addrs_buff.as_ptr(), addrs_len);
             eprintln!(
-                "result: {},  addrs_len: {}, addrs_u8: {:?}",
-                result, addrs_len, addrs_buff,
+                "fd: {}, result: {},  addrs_len: {}, addrs_u8: {:?}",
+                fd, result, addrs_len, addrs_buff,
             );
             let socketaddr = os_socketaddr.into_addr().unwrap();
-            Ok((SctpConnectedSocket::from_rawfd(result as RawFd), socketaddr))
+            Ok((
+                SctpConnectedSocket::from_rawfd(result as RawFd)?,
+                socketaddr,
+            ))
         }
     }
 }

--- a/sctp-rs/src/lib.rs
+++ b/sctp-rs/src/lib.rs
@@ -35,5 +35,6 @@ mod types;
 pub use types::{
     AssociationChange, BindxFlags, SctpAssocChangeState, SctpAssociationId, SctpCmsgType,
     SctpEvent, SctpNotification, SctpNotificationOrData, SctpNxtInfo, SctpRcvInfo,
-    SctpReceivedData, SctpSendData, SctpSendInfo, SocketToAssociation, SubscribeEventAssocId,
+    SctpReceivedData, SctpSendData, SctpSendInfo, SctpStatus, SocketToAssociation,
+    SubscribeEventAssocId,
 };

--- a/sctp-rs/src/listener.rs
+++ b/sctp-rs/src/listener.rs
@@ -24,8 +24,8 @@ pub struct SctpListener {
 
 impl SctpListener {
     /// Accept on a given socket (valid only for `OneToOne` type sockets).
-    pub fn accept(&self) -> std::io::Result<(SctpConnectedSocket, SocketAddr)> {
-        accept_internal(*self.inner.get_ref())
+    pub async fn accept(&self) -> std::io::Result<(SctpConnectedSocket, SocketAddr)> {
+        accept_internal(&self.inner).await
     }
 
     /// Shutdown on the socket

--- a/sctp-rs/src/listener.rs
+++ b/sctp-rs/src/listener.rs
@@ -3,6 +3,8 @@
 use std::net::SocketAddr;
 use std::os::unix::io::{AsRawFd, RawFd};
 
+use tokio::io::unix::AsyncFd;
+
 #[allow(unused)]
 use crate::internal::*;
 use crate::{
@@ -17,25 +19,25 @@ use crate::{
 /// [`crate::SctpSocket`] is consumed when this structure is created. See
 /// [`crate::SctpSocket::listen`] for more details.
 pub struct SctpListener {
-    inner: RawFd,
+    inner: AsyncFd<RawFd>,
 }
 
 impl SctpListener {
     /// Accept on a given socket (valid only for `OneToOne` type sockets).
     pub fn accept(&self) -> std::io::Result<(SctpConnectedSocket, SocketAddr)> {
-        accept_internal(self.inner)
+        accept_internal(*self.inner.get_ref())
     }
 
     /// Shutdown on the socket
     pub fn shutdown(&self, how: std::net::Shutdown) -> std::io::Result<()> {
-        shutdown_internal(self.inner, how)
+        shutdown_internal(*self.inner.get_ref(), how)
     }
 
     /// Binds to one or more local addresses. See: Section 9.1 RFC 6458
     ///
     /// It is possible to call `sctp_bindx` on an already 'bound' (that is 'listen'ing socket.)
     pub fn sctp_bindx(&self, addrs: &[SocketAddr], flags: BindxFlags) -> std::io::Result<()> {
-        sctp_bindx_internal(self.inner, addrs, flags)
+        sctp_bindx_internal(*self.inner.get_ref(), addrs, flags)
     }
 
     /// Peels off a connected SCTP association from the listening socket. See: Section 9.2 RFC 6458
@@ -43,8 +45,8 @@ impl SctpListener {
         &self,
         assoc_id: SctpAssociationId,
     ) -> std::io::Result<SctpConnectedSocket> {
-        let fd = sctp_peeloff_internal(self.inner, assoc_id)?;
-        Ok(SctpConnectedSocket::from_rawfd(fd.as_raw_fd()))
+        let fd = sctp_peeloff_internal(*self.inner.get_ref(), assoc_id)?;
+        Ok(SctpConnectedSocket::from_rawfd(fd.as_raw_fd())?)
     }
 
     /// Get Peer Address(es) for the given Association ID. See: Section 9.3 RFC 6458
@@ -53,26 +55,26 @@ impl SctpListener {
     /// associations that are not peeled off, we are performing IO operations on the listening
     /// socket itself.
     pub fn sctp_getpaddrs(&self, assoc_id: SctpAssociationId) -> std::io::Result<Vec<SocketAddr>> {
-        sctp_getpaddrs_internal(self.inner, assoc_id)
+        sctp_getpaddrs_internal(*self.inner.get_ref(), assoc_id)
     }
 
     /// Get's the Local Addresses for the association. See: Section 9.4 RFC 6458
     pub fn sctp_getladdrs(&self, assoc_id: SctpAssociationId) -> std::io::Result<Vec<SocketAddr>> {
-        sctp_getladdrs_internal(self.inner, assoc_id)
+        sctp_getladdrs_internal(*self.inner.get_ref(), assoc_id)
     }
 
     /// Receive Data or Notification from the listening socket.
     ///
     /// This function returns either a notification or the data.
     pub fn sctp_recv(&self) -> std::io::Result<SctpNotificationOrData> {
-        sctp_recvmsg_internal(self.inner)
+        sctp_recvmsg_internal(*self.inner.get_ref())
     }
 
     /// Send Data and Anciliary data if any on the SCTP Socket.
     ///
     /// This function returns the result of Sending data on the socket.
     pub fn sctp_send(&self, to: SocketAddr, data: SctpSendData) -> std::io::Result<()> {
-        sctp_sendmsg_internal(self.inner, Some(to), data)
+        sctp_sendmsg_internal(*self.inner.get_ref(), Some(to), data)
     }
 
     /// Event Subscription for the socket.
@@ -81,7 +83,7 @@ impl SctpListener {
         event: SctpEvent,
         assoc_id: SubscribeEventAssocId,
     ) -> std::io::Result<()> {
-        sctp_subscribe_event_internal(self.inner, event, assoc_id, true)
+        sctp_subscribe_event_internal(*self.inner.get_ref(), event, assoc_id, true)
     }
 
     /// Event Unsubscription for the socket.
@@ -90,18 +92,20 @@ impl SctpListener {
         event: SctpEvent,
         assoc_id: SubscribeEventAssocId,
     ) -> std::io::Result<()> {
-        sctp_subscribe_event_internal(self.inner, event, assoc_id, false)
+        sctp_subscribe_event_internal(*self.inner.get_ref(), event, assoc_id, false)
     }
 
     // functions not part of public APIs
-    pub(crate) fn from_raw_fd(fd: RawFd) -> Self {
-        Self { inner: fd }
+    pub(crate) fn from_raw_fd(fd: RawFd) -> std::io::Result<Self> {
+        Ok(Self {
+            inner: AsyncFd::new(fd)?,
+        })
     }
 }
 
 impl Drop for SctpListener {
     // Drop for `SctpListener`. We close the `inner` RawFd
     fn drop(&mut self) {
-        close_internal(self.inner);
+        close_internal(*self.inner.get_ref());
     }
 }

--- a/sctp-rs/src/listener.rs
+++ b/sctp-rs/src/listener.rs
@@ -66,15 +66,15 @@ impl SctpListener {
     /// Receive Data or Notification from the listening socket.
     ///
     /// This function returns either a notification or the data.
-    pub fn sctp_recv(&self) -> std::io::Result<SctpNotificationOrData> {
-        sctp_recvmsg_internal(*self.inner.get_ref())
+    pub async fn sctp_recv(&self) -> std::io::Result<SctpNotificationOrData> {
+        sctp_recvmsg_internal(&self.inner).await
     }
 
     /// Send Data and Anciliary data if any on the SCTP Socket.
     ///
     /// This function returns the result of Sending data on the socket.
-    pub fn sctp_send(&self, to: SocketAddr, data: SctpSendData) -> std::io::Result<()> {
-        sctp_sendmsg_internal(*self.inner.get_ref(), Some(to), data)
+    pub async fn sctp_send(&self, to: SocketAddr, data: SctpSendData) -> std::io::Result<()> {
+        sctp_sendmsg_internal(&self.inner, Some(to), data).await
     }
 
     /// Event Subscription for the socket.

--- a/sctp-rs/src/listener.rs
+++ b/sctp-rs/src/listener.rs
@@ -9,7 +9,7 @@ use tokio::io::unix::AsyncFd;
 use crate::internal::*;
 use crate::{
     types::SctpAssociationId, BindxFlags, SctpConnectedSocket, SctpEvent, SctpNotificationOrData,
-    SctpSendData, SubscribeEventAssocId,
+    SctpSendData, SctpStatus, SubscribeEventAssocId,
 };
 
 /// A structure representing a socket that is listening for incoming SCTP Connections.
@@ -93,6 +93,11 @@ impl SctpListener {
         assoc_id: SubscribeEventAssocId,
     ) -> std::io::Result<()> {
         sctp_subscribe_event_internal(*self.inner.get_ref(), event, assoc_id, false)
+    }
+
+    /// Get's the status of the connection associated with the association ID
+    pub fn sctp_get_status(&self, assoc_id: SctpAssociationId) -> std::io::Result<SctpStatus> {
+        sctp_get_status_internal(*self.inner.get_ref(), assoc_id)
     }
 
     // functions not part of public APIs

--- a/sctp-rs/src/socket.rs
+++ b/sctp-rs/src/socket.rs
@@ -24,19 +24,17 @@ pub struct SctpSocket {
 
 impl SctpSocket {
     /// Create a New Socket for IPV4
-    pub fn new_v4(assoc: SocketToAssociation) -> Self {
-        Self {
-            inner: AsyncFd::new(sctp_socket_internal(libc::AF_INET, assoc))
-                .expect("AsyncFd get failed."),
-        }
+    pub fn new_v4(assoc: SocketToAssociation) -> std::io::Result<Self> {
+        Ok(Self {
+            inner: AsyncFd::new(sctp_socket_internal(libc::AF_INET, assoc)?)?,
+        })
     }
 
     /// Create a New Socket for IPV6
-    pub fn new_v6(assoc: crate::SocketToAssociation) -> Self {
-        Self {
-            inner: AsyncFd::new(sctp_socket_internal(libc::AF_INET6, assoc))
-                .expect("AsyncFd get failed."),
-        }
+    pub fn new_v6(assoc: crate::SocketToAssociation) -> std::io::Result<Self> {
+        Ok(Self {
+            inner: AsyncFd::new(sctp_socket_internal(libc::AF_INET6, assoc)?)?,
+        })
     }
 
     /// Bind a socket to a given IP Address

--- a/sctp-rs/src/socket.rs
+++ b/sctp-rs/src/socket.rs
@@ -6,7 +6,7 @@ use std::os::unix::io::RawFd;
 use tokio::io::unix::AsyncFd;
 
 use crate::{
-    BindxFlags, SctpAssociationId, SctpConnectedSocket, SctpEvent, SctpListener,
+    BindxFlags, SctpAssociationId, SctpConnectedSocket, SctpEvent, SctpListener, SctpStatus,
     SocketToAssociation, SubscribeEventAssocId,
 };
 
@@ -56,7 +56,7 @@ impl SctpSocket {
         self,
         addr: SocketAddr,
     ) -> std::io::Result<(SctpConnectedSocket, SctpAssociationId)> {
-        sctp_connectx_internal(self.inner.into_inner(), &[addr])
+        sctp_connectx_internal(self.inner, &[addr]).await
     }
 
     /// Section 9.1 RFC 6458
@@ -71,11 +71,11 @@ impl SctpSocket {
     /// An Unbound socket when connected to a remote end would return a
     /// [`SctpConnectedSocket`][`crate::SctpConnectedSocket`] and an
     /// [`SctpAssociationId`][`crate::types::SctpAssociationId`] tuple.
-    pub fn sctp_connectx(
+    pub async fn sctp_connectx(
         self,
         addrs: &[SocketAddr],
     ) -> std::io::Result<(SctpConnectedSocket, SctpAssociationId)> {
-        sctp_connectx_internal(self.inner.into_inner(), addrs)
+        sctp_connectx_internal(self.inner, addrs).await
     }
 
     /// Event Subscription for the socket.
@@ -115,5 +115,10 @@ impl SctpSocket {
     /// Request to receive `SctpNxtInfo` ancillary data
     pub fn sctp_request_nxtinfo(&self, on: bool) -> std::io::Result<()> {
         request_nxtinfo_internal(*self.inner.get_ref(), on)
+    }
+
+    /// Get's the status of the connection associated with the association ID
+    pub fn sctp_get_status(&self, assoc_id: SctpAssociationId) -> std::io::Result<SctpStatus> {
+        sctp_get_status_internal(*self.inner.get_ref(), assoc_id)
     }
 }

--- a/sctp-rs/src/types.rs
+++ b/sctp-rs/src/types.rs
@@ -183,4 +183,47 @@ pub enum SctpCmsgType {
     SctpDstAddrV6,
 }
 
+/// Constants related to `enm sctp_sstat_state`
+#[repr(i32)]
+#[derive(Debug, Clone, Default)]
+pub enum SctpConnState {
+    #[default]
+    Empty = 0,
+    Closed,
+    CookieWait,
+    CookieEchoed,
+    Established,
+    ShutdownPending,
+    ShutdownSent,
+    ShutdownReceived,
+    ShutdownAckSent,
+}
+
+/// SctpPeerAddress:
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct SctpPeerAddress {
+    assoc_id: SctpAssociationId,
+    address: libc::sockaddr_storage,
+    state: i32,
+    cwnd: u32,
+    srtt: u32,
+    rto: u32,
+    mtu: u32,
+}
+
+/// SctpStatus: Status of an SCTP Connection
+#[repr(C)]
+#[derive(Clone)]
+pub struct SctpStatus {
+    pub assoc_id: SctpAssociationId,
+    pub state: SctpConnState,
+    pub rwnd: u32,
+    pub unacked_data: u16,
+    pub pending_data: u16,
+    pub instreams: u16,
+    pub outstreams: u16,
+    pub fragmentation_pt: u32,
+    pub peer_primary: SctpPeerAddress,
+}
 pub(crate) mod internal;

--- a/sctp-rs/src/types/internal.rs
+++ b/sctp-rs/src/types/internal.rs
@@ -54,3 +54,13 @@ pub(crate) struct SctpInitMsg {
     pub(crate) retries: u16,
     pub(crate) timeout: u16, // in miliseconds
 }
+
+// Structure used by connectx (using SCTP_SOCKOPT_CONNECTX3). This is required to get the
+// `assoc_id` in the case of non blocking sockets.
+#[repr(C)]
+#[derive(Debug)]
+pub(crate) struct SctpConnectxParam {
+    pub(crate) assoc_id: SctpAssociationId,
+    pub(crate) addrs_size: libc::c_int,
+    pub(crate) addrs: *mut u8,
+}

--- a/sctp-rs/tests/connected_socket/mod.rs
+++ b/sctp-rs/tests/connected_socket/mod.rs
@@ -1,9 +1,9 @@
 use sctp_rs::*;
 
-#[test]
-fn bindx_not_supported() {
+#[tokio::test]
+async fn bindx_not_supported() {
     let connected = SctpConnectedSocket::from_rawfd(42);
-    let bindaddr = "127.0.0.1:8080".parse().unwrap();
-    let result = connected.sctp_bindx(&[bindaddr], BindxFlags::Add);
-    assert!(result.is_err(), "{:#?}", result.ok().unwrap());
+    assert!(connected.is_err(), "{:?}", connected.ok().unwrap());
+
+    // TODO: Write real test
 }

--- a/sctp-rs/tests/listener/mod.rs
+++ b/sctp-rs/tests/listener/mod.rs
@@ -13,7 +13,7 @@ async fn listening_one_2_one_listen_accept_success() {
     eprintln!("2");
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
-    let accept = listener.accept();
+    let accept = listener.accept().await;
     eprintln!("3");
     assert!(accept.is_ok(), "{:#?}", accept.err().unwrap());
 
@@ -31,7 +31,7 @@ async fn listening_one_2_many_listen_accept_failure() {
     let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
-    let accept = listener.accept();
+    let accept = listener.accept().await;
     assert!(accept.is_err(), "{:#?}", accept.ok().unwrap());
 }
 

--- a/sctp-rs/tests/listener/mod.rs
+++ b/sctp-rs/tests/listener/mod.rs
@@ -9,7 +9,7 @@ async fn listening_one_2_one_listen_accept_success() {
 
     let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
     eprintln!("1");
-    let assoc_id = client_socket.sctp_connectx(&[bindaddr]);
+    let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     eprintln!("2");
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
@@ -28,7 +28,7 @@ async fn listening_one_2_many_listen_accept_failure() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToMany, true);
 
     let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
-    let assoc_id = client_socket.sctp_connectx(&[bindaddr]);
+    let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
     let accept = listener.accept();
@@ -66,7 +66,7 @@ async fn listening_socket_one2one_connected_peeloff_failure() {
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
     let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
-    let assoc_id = client_socket.sctp_connectx(&[bindaddr]);
+    let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
     let received = listener.sctp_peeloff(0);
@@ -82,7 +82,7 @@ async fn listening_socket_one2many_connected_peeloff_success() {
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
     let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
-    let assoc_id = client_socket.sctp_connectx(&[bindaddr]);
+    let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
     let result = listener.sctp_recv();

--- a/sctp-rs/tests/listener/mod.rs
+++ b/sctp-rs/tests/listener/mod.rs
@@ -3,15 +3,18 @@ use sctp_rs::*;
 use std::net::SocketAddr;
 
 // Tests for `accept` API for Listening Socket.
-#[test]
-fn listening_one_2_one_listen_accept_success() {
+#[tokio::test]
+async fn listening_one_2_one_listen_accept_success() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToOne, true);
 
     let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
+    eprintln!("1");
     let assoc_id = client_socket.sctp_connectx(&[bindaddr]);
+    eprintln!("2");
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
     let accept = listener.accept();
+    eprintln!("3");
     assert!(accept.is_ok(), "{:#?}", accept.err().unwrap());
 
     // Get Peer Address
@@ -20,8 +23,8 @@ fn listening_one_2_one_listen_accept_success() {
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 }
 
-#[test]
-fn listening_one_2_many_listen_accept_failure() {
+#[tokio::test]
+async fn listening_one_2_many_listen_accept_failure() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToMany, true);
 
     let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
@@ -36,8 +39,8 @@ fn listening_one_2_many_listen_accept_failure() {
 // TODO:
 
 // Test for `sctp_bindx` API for Listening Socket.
-#[test]
-fn listening_sctp_bindx_add_success() {
+#[tokio::test]
+async fn listening_sctp_bindx_add_success() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToOne, true);
 
     let bindx_bindaddr: SocketAddr = format!("127.0.0.53:{}", bindaddr.port()).parse().unwrap();
@@ -46,16 +49,16 @@ fn listening_sctp_bindx_add_success() {
 }
 
 // Tests for `sctp_peeloff` API for Listening Socket.
-#[test]
-fn listening_socket_no_connect_peeloff_failure() {
+#[tokio::test]
+async fn listening_socket_no_connect_peeloff_failure() {
     let (listener, _) = create_socket_bind_and_listen(SocketToAssociation::OneToMany, true);
 
     let result = listener.sctp_peeloff(42);
     assert!(result.is_err(), "{:#?}", result.ok().unwrap());
 }
 
-#[test]
-fn listening_socket_one2one_connected_peeloff_failure() {
+#[tokio::test]
+async fn listening_socket_one2one_connected_peeloff_failure() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToOne, true);
 
     let result =
@@ -70,8 +73,8 @@ fn listening_socket_one2one_connected_peeloff_failure() {
     assert!(received.is_err(), "{:#?}", received.ok().unwrap());
 }
 
-#[test]
-fn listening_socket_one2many_connected_peeloff_success() {
+#[tokio::test]
+async fn listening_socket_one2many_connected_peeloff_success() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToMany, true);
 
     let result =

--- a/sctp-rs/tests/listener/mod.rs
+++ b/sctp-rs/tests/listener/mod.rs
@@ -86,7 +86,7 @@ async fn listening_socket_one2many_connected_peeloff_success() {
     let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
-    let result = listener.sctp_recv();
+    let result = listener.sctp_recv().await;
     assert!(result.is_ok(), "{:#}", result.err().unwrap());
 
     let notification = result.unwrap();

--- a/sctp-rs/tests/listener/mod.rs
+++ b/sctp-rs/tests/listener/mod.rs
@@ -1,4 +1,4 @@
-use crate::create_socket_bind_and_listen;
+use crate::{create_client_socket, create_socket_bind_and_listen};
 use sctp_rs::*;
 use std::net::SocketAddr;
 
@@ -7,14 +7,12 @@ use std::net::SocketAddr;
 async fn listening_one_2_one_listen_accept_success() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToOne, true);
 
-    let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
-    eprintln!("1");
+    let client_socket = create_client_socket(SocketToAssociation::OneToOne, true);
+
     let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
-    eprintln!("2");
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
     let accept = listener.accept().await;
-    eprintln!("3");
     assert!(accept.is_ok(), "{:#?}", accept.err().unwrap());
 
     // Get Peer Address
@@ -27,7 +25,8 @@ async fn listening_one_2_one_listen_accept_success() {
 async fn listening_one_2_many_listen_accept_failure() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToMany, true);
 
-    let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
+    let client_socket = create_client_socket(SocketToAssociation::OneToMany, true);
+
     let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
@@ -65,7 +64,8 @@ async fn listening_socket_one2one_connected_peeloff_failure() {
         listener.sctp_subscribe_event(SctpEvent::Association, SubscribeEventAssocId::Future);
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
-    let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
+    let client_socket = create_client_socket(SocketToAssociation::OneToOne, true);
+
     let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
@@ -81,7 +81,8 @@ async fn listening_socket_one2many_connected_peeloff_success() {
         listener.sctp_subscribe_event(SctpEvent::Association, SubscribeEventAssocId::Future);
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
-    let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
+    let client_socket = create_client_socket(SocketToAssociation::OneToMany, true);
+
     let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 

--- a/sctp-rs/tests/mod.rs
+++ b/sctp-rs/tests/mod.rs
@@ -15,6 +15,9 @@ fn create_socket_bind_and_listen(
     } else {
         SctpSocket::new_v6(association)
     };
+    assert!(sctp_socket.is_ok(), "{:#?}", sctp_socket.err().unwrap());
+    let sctp_socket = sctp_socket.unwrap();
+
     let port = TEST_PORT_NO.fetch_add(1, Ordering::SeqCst);
     let bindaddr: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
 
@@ -25,6 +28,17 @@ fn create_socket_bind_and_listen(
     assert!(listener.is_ok(), "{:#?}", listener.err().unwrap());
 
     (listener.unwrap(), bindaddr)
+}
+
+fn create_client_socket(association: SocketToAssociation, v4: bool) -> SctpSocket {
+    let client_socket = if v4 {
+        SctpSocket::new_v4(association)
+    } else {
+        SctpSocket::new_v6(association)
+    };
+    assert!(client_socket.is_ok(), "{:#?}", client_socket.err().unwrap());
+
+    client_socket.unwrap()
 }
 
 mod connected_socket;

--- a/sctp-rs/tests/socket/mod.rs
+++ b/sctp-rs/tests/socket/mod.rs
@@ -37,10 +37,10 @@ async fn socket_connect_basic_send_recv_req_info_on_and_off() {
         payload: b"hello world!".to_vec(),
         snd_info: None,
     };
-    let result = listener.sctp_send(client_addr, senddata.clone());
+    let result = listener.sctp_send(client_addr, senddata.clone()).await;
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
-    let result = connected.sctp_recv();
+    let result = connected.sctp_recv().await;
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
     let data = result.unwrap();
     assert!(
@@ -77,10 +77,10 @@ async fn socket_connect_basic_send_recv_req_info_on_and_off() {
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
     // Again send the data to client
-    let result = listener.sctp_send(client_addr, senddata);
+    let result = listener.sctp_send(client_addr, senddata).await;
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
-    let result = connected.sctp_recv();
+    let result = connected.sctp_recv().await;
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
     let data = result.unwrap();
     assert!(
@@ -137,15 +137,15 @@ async fn socket_send_recv_nxtinfo_test() {
         payload: b"hello world!".to_vec(),
         snd_info: None,
     };
-    let result = listener.sctp_send(client_addr, senddata.clone());
+    let result = listener.sctp_send(client_addr, senddata.clone()).await;
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
     // Send again
-    let result = listener.sctp_send(client_addr, senddata.clone());
+    let result = listener.sctp_send(client_addr, senddata.clone()).await;
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
     // First Receive nxtinfo should not be none.
-    let result = connected.sctp_recv();
+    let result = connected.sctp_recv().await;
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
     let data = result.unwrap();
     assert!(
@@ -172,7 +172,7 @@ async fn socket_send_recv_nxtinfo_test() {
     };
 
     // First Receive nxtinfo should not be none.
-    let result = connected.sctp_recv();
+    let result = connected.sctp_recv().await;
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
     let data = result.unwrap();
     assert!(
@@ -216,7 +216,7 @@ async fn socket_init_params_set_ostreams_success() {
     let assoc_id = client_socket.sctp_connectx(&[bindaddr]).await;
     assert!(assoc_id.is_ok(), "{:#?}", assoc_id.err().unwrap());
 
-    let result = listener.sctp_recv();
+    let result = listener.sctp_recv().await;
     assert!(result.is_ok(), "{:#}", result.err().unwrap());
 
     let notification = result.unwrap();

--- a/sctp-rs/tests/socket/mod.rs
+++ b/sctp-rs/tests/socket/mod.rs
@@ -5,8 +5,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 #[allow(unused)]
 use sctp_rs::*;
 
-#[test]
-fn socket_connect_basic_send_recv_req_info_on_and_off() {
+#[tokio::test]
+async fn socket_connect_basic_send_recv_req_info_on_and_off() {
     let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
     let result =
         client_socket.sctp_subscribe_event(SctpEvent::Association, SubscribeEventAssocId::Current);
@@ -105,8 +105,8 @@ fn socket_connect_basic_send_recv_req_info_on_and_off() {
     };
 }
 
-#[test]
-fn socket_send_recv_nxtinfo_test() {
+#[tokio::test]
+async fn socket_send_recv_nxtinfo_test() {
     let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
     let result =
         client_socket.sctp_subscribe_event(SctpEvent::Association, SubscribeEventAssocId::Current);
@@ -197,8 +197,8 @@ fn socket_send_recv_nxtinfo_test() {
     };
 }
 
-#[test]
-fn socket_init_params_set_ostreams_success() {
+#[tokio::test]
+async fn socket_init_params_set_ostreams_success() {
     let (listener, bindaddr) = create_socket_bind_and_listen(SocketToAssociation::OneToMany, true);
 
     let result =
@@ -254,8 +254,8 @@ fn socket_init_params_set_ostreams_success() {
     };
 }
 
-#[test]
-fn socket_sctp_req_recv_info_success() {
+#[tokio::test]
+async fn socket_sctp_req_recv_info_success() {
     let one2one_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
     let result = one2one_socket.sctp_request_rcvinfo(true);
     assert!(result.is_ok(), "{:?}", result.err().unwrap());
@@ -265,8 +265,8 @@ fn socket_sctp_req_recv_info_success() {
     assert!(result.is_ok(), "{:?}", result.err().unwrap());
 }
 
-#[test]
-fn test_bind_success() {
+#[tokio::test]
+async fn test_bind_success() {
     let sctp_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
     let bindaddr = Ipv4Addr::UNSPECIFIED;
 
@@ -274,8 +274,8 @@ fn test_bind_success() {
     assert!(result.is_ok(), "{:?}", result.err().unwrap());
 }
 
-#[test]
-fn test_bindx_inaddr_any_add_success() {
+#[tokio::test]
+async fn test_bindx_inaddr_any_add_success() {
     let sctp_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
     let bindaddr = Ipv4Addr::UNSPECIFIED;
 
@@ -284,8 +284,8 @@ fn test_bindx_inaddr_any_add_success() {
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 }
 
-#[test]
-fn test_bindx_inaddr6_any_add_success() {
+#[tokio::test]
+async fn test_bindx_inaddr6_any_add_success() {
     let sctp_socket = SctpSocket::new_v6(SocketToAssociation::OneToOne);
     let bindaddr = Ipv6Addr::UNSPECIFIED;
 
@@ -294,8 +294,8 @@ fn test_bindx_inaddr6_any_add_success() {
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 }
 
-#[test]
-fn test_bindx_inaddr_any_add_and_remove_failure() {
+#[tokio::test]
+async fn test_bindx_inaddr_any_add_and_remove_failure() {
     let sctp_socket = SctpSocket::new_v6(SocketToAssociation::OneToOne);
     let bindaddr6_localhost = Ipv6Addr::LOCALHOST;
 

--- a/sctp-rs/tests/socket/mod.rs
+++ b/sctp-rs/tests/socket/mod.rs
@@ -1,4 +1,4 @@
-use super::create_socket_bind_and_listen;
+use super::{create_client_socket, create_socket_bind_and_listen};
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
@@ -7,7 +7,8 @@ use sctp_rs::*;
 
 #[tokio::test]
 async fn socket_connect_basic_send_recv_req_info_on_and_off() {
-    let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
+    let client_socket = create_client_socket(SocketToAssociation::OneToMany, true);
+
     let result =
         client_socket.sctp_subscribe_event(SctpEvent::Association, SubscribeEventAssocId::Current);
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
@@ -108,7 +109,7 @@ async fn socket_connect_basic_send_recv_req_info_on_and_off() {
 
 #[tokio::test]
 async fn socket_send_recv_nxtinfo_test() {
-    let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
+    let client_socket = create_client_socket(SocketToAssociation::OneToMany, true);
     let result =
         client_socket.sctp_subscribe_event(SctpEvent::Association, SubscribeEventAssocId::Current);
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
@@ -208,7 +209,7 @@ async fn socket_init_params_set_ostreams_success() {
 
     let client_ostreams = 100;
     let client_istreams = 5;
-    let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
+    let client_socket = create_client_socket(SocketToAssociation::OneToMany, true);
     let result = client_socket.sctp_setup_init_params(client_ostreams, client_istreams, 0, 0);
     assert!(result.is_ok(), "{:#?}", result.err().unwrap());
 
@@ -257,18 +258,18 @@ async fn socket_init_params_set_ostreams_success() {
 
 #[tokio::test]
 async fn socket_sctp_req_recv_info_success() {
-    let one2one_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
+    let one2one_socket = create_client_socket(SocketToAssociation::OneToOne, true);
     let result = one2one_socket.sctp_request_rcvinfo(true);
     assert!(result.is_ok(), "{:?}", result.err().unwrap());
 
-    let one2many_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
+    let one2many_socket = create_client_socket(SocketToAssociation::OneToMany, true);
     let result = one2many_socket.sctp_request_rcvinfo(true);
     assert!(result.is_ok(), "{:?}", result.err().unwrap());
 }
 
 #[tokio::test]
 async fn test_bind_success() {
-    let sctp_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
+    let sctp_socket = create_client_socket(SocketToAssociation::OneToOne, true);
     let bindaddr = Ipv4Addr::UNSPECIFIED;
 
     let result = sctp_socket.bind(SocketAddr::new(IpAddr::V4(bindaddr), 0));
@@ -277,7 +278,7 @@ async fn test_bind_success() {
 
 #[tokio::test]
 async fn test_bindx_inaddr_any_add_success() {
-    let sctp_socket = SctpSocket::new_v4(SocketToAssociation::OneToOne);
+    let sctp_socket = create_client_socket(SocketToAssociation::OneToOne, true);
     let bindaddr = Ipv4Addr::UNSPECIFIED;
 
     let result =
@@ -287,7 +288,7 @@ async fn test_bindx_inaddr_any_add_success() {
 
 #[tokio::test]
 async fn test_bindx_inaddr6_any_add_success() {
-    let sctp_socket = SctpSocket::new_v6(SocketToAssociation::OneToOne);
+    let sctp_socket = create_client_socket(SocketToAssociation::OneToOne, false);
     let bindaddr = Ipv6Addr::UNSPECIFIED;
 
     let result =
@@ -297,7 +298,7 @@ async fn test_bindx_inaddr6_any_add_success() {
 
 #[tokio::test]
 async fn test_bindx_inaddr_any_add_and_remove_failure() {
-    let sctp_socket = SctpSocket::new_v6(SocketToAssociation::OneToOne);
+    let sctp_socket = create_client_socket(SocketToAssociation::OneToOne, false);
     let bindaddr6_localhost = Ipv6Addr::LOCALHOST;
 
     let result = sctp_socket.sctp_bindx(
@@ -315,7 +316,7 @@ async fn test_bindx_inaddr_any_add_and_remove_failure() {
 
 #[tokio::test]
 async fn test_connect_no_listen_failure() {
-    let client_socket = SctpSocket::new_v4(SocketToAssociation::OneToMany);
+    let client_socket = create_client_socket(SocketToAssociation::OneToMany, true);
     let connect_addr: SocketAddr = "127.0.0.53:8080".parse().unwrap();
 
     let result = client_socket.connect(connect_addr).await;


### PR DESCRIPTION
Getting started with tokio support for async

- Made the `RawFd` descriptors `AsyncFd`
- All the tests are `tokio::test` now
- Since `AsyncFd::new` can fail, the return types of `from_rawfd` are `Result` types now
- Some tests need to be revisited