### PR TITLE
Hanging Sockets on Error

### DIFF
--- a/sctp-rs/src/internal.rs
+++ b/sctp-rs/src/internal.rs
@@ -625,7 +625,7 @@ pub(crate) async fn sctp_sendmsg_internal(
             std::ptr::copy(
                 std::ptr::addr_of!(snd_info) as *const _,
                 libc::CMSG_DATA(cmsg_hdr) as *mut _ as *mut u8,
-                std::mem::size_of::<SendInfo>().try_into().unwrap(),
+                std::mem::size_of::<SendInfo>(),
             );
         }
 

--- a/sctp-rs/src/internal.rs
+++ b/sctp-rs/src/internal.rs
@@ -314,6 +314,7 @@ pub(crate) async fn sctp_connectx_internal(
                     "Error: '{}' while connecting using `getsockopt`.",
                     std::io::Error::last_os_error()
                 );
+                close_internal(&fd);
                 return Err(last_error);
             }
         }
@@ -330,6 +331,7 @@ pub(crate) async fn sctp_connectx_internal(
                 log::error!("Received `EINVAL`, while getting status, returning `ECONNREFUSED`.");
                 std::io::Error::from_raw_os_error(libc::ECONNREFUSED)
             };
+            close_internal(&fd);
             return Err(err);
         }
 

--- a/sctp-rs/src/internal.rs
+++ b/sctp-rs/src/internal.rs
@@ -314,6 +314,9 @@ pub(crate) async fn sctp_connectx_internal(
                     "Error: '{}' while connecting using `getsockopt`.",
                     std::io::Error::last_os_error()
                 );
+                // if we get here, `fd` won't be consumed by a `ConnectedSocket` and thus
+                // won't be closed on drop. Need to manually close here to avoid leaving
+                // sockets behind if the application does not exit.
                 close_internal(&fd);
                 return Err(last_error);
             }
@@ -331,6 +334,9 @@ pub(crate) async fn sctp_connectx_internal(
                 log::error!("Received `EINVAL`, while getting status, returning `ECONNREFUSED`.");
                 std::io::Error::from_raw_os_error(libc::ECONNREFUSED)
             };
+            // if we get here, `fd` won't be consumed by a `ConnectedSocket` and thus
+            // won't be closed on drop. Need to manually close here to avoid leaving
+            // sockets behind if the application does not exit.
             close_internal(&fd);
             return Err(err);
         }


### PR DESCRIPTION
I have an application that tries to open an SCTP connection to a remote peer that may or may not exist.  This operation takes place in a sub-task and continually retries over time until a connection is made.  

I noticed that when I restart only the task and not the entire application (which is my preference) the `sctp-rs` crate leaves behind a socket for each connection try.  This is occurring because the fd close does not happen on drop because the fd is not consumed by the `ConnectedSocket` after open.

This PR addresses that issue as well as a minor clippy suggestion that should have no overall affect.